### PR TITLE
Remove notification while copying board

### DIFF
--- a/models/boards.js
+++ b/models/boards.js
@@ -640,10 +640,18 @@ Boards.attachSchema(
 Boards.helpers({
   copy() {
     const oldId = this._id;
+    const oldWatchers = this.watchers ? this.watchers.slice() : [];
     delete this._id;
     delete this.slug;
     this.title = this.copyTitle();
     const _id = Boards.insert(this);
+
+    // Temporary remove watchers to disable notifications
+      Boards.update(_id, {
+        $set: {
+          watchers: []
+        },
+    });
 
     // Copy all swimlanes in board
     ReactiveCache.getSwimlanes({
@@ -695,6 +703,12 @@ Boards.helpers({
       rule.triggerId = triggersMap[rule.triggerId];
       Rules.insert(rule);
     });
+
+    // Re-set Watchers to reenable notification
+    Boards.update(_id, {
+      $set: { watchers: oldWatchers }
+    });
+
     return _id;
   },
   /**


### PR DESCRIPTION
1. It takes too long while server stops after 2 minutes (#5371).
2. It is useless, because when you copy a board, most of the time your users don't want to be notified of every copied cards.

This closes (#5371), copy board is back to 8 sec. But, this doesn't explain why those notification takes so long and why server stops after 2 minutes.